### PR TITLE
Migrate deployments to use the apps/v1 API

### DIFF
--- a/kubernetes/deployments/auth.yaml
+++ b/kubernetes/deployments/auth.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: auth
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: "auth"
   template:
     metadata:
       labels:

--- a/kubernetes/deployments/frontend.yaml
+++ b/kubernetes/deployments/frontend.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: frontend
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: "frontend"
   template:
     metadata:
       labels:

--- a/kubernetes/deployments/hello.yaml
+++ b/kubernetes/deployments/hello.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: "hello"
   template:
     metadata:
       labels:


### PR DESCRIPTION
Deprecated API Deployment was removed in the extensions/v1beta1 API group with the Kubernetes v1.16 release.
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

Fixes https://github.com/udacity/ud615/issues/10