### PR TITLE
update JWT calling conventions

### DIFF
--- a/app/go.mod
+++ b/app/go.mod
@@ -1,0 +1,9 @@
+module github.com/udacity/ud615/app
+
+// go: no requirements found in Godeps/Godeps.json
+
+require (
+	github.com/braintree/manners v0.0.0-20160418043613-82a8879fc5fd
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e
+)

--- a/app/go.sum
+++ b/app/go.sum
@@ -1,0 +1,13 @@
+github.com/braintree/manners v0.0.0-20160418043613-82a8879fc5fd h1:ePesaBzdTmoMQjwqRCLP2jY+jjWMBpwws/LEQdt1fMM=
+github.com/braintree/manners v0.0.0-20160418043613-82a8879fc5fd/go.mod h1:TNehV1AhBwtT7Bd+rh8G6MoGDbBLNs/sKdk3nvr4Yzg=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/udacity/ud615 v0.0.0-20201012185024-899178a48b06 h1:pBugF2zXwnQ6gGx7A9pMZOqxduIXWDPdLOVB97rwnIA=
+golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e h1:gsTQYXdTw2Gq7RBsWvlQ91b+aEQ6bXFUngBGuR8sPpI=
+golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/app/handlers/jwt.go
+++ b/app/handlers/jwt.go
@@ -4,11 +4,12 @@ import (
 	"net/http"
 
 	"github.com/dgrijalva/jwt-go"
+	"github.com/dgrijalva/jwt-go/request"
 )
 
 func JWTAuthHandler(h http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		token, err := jwt.ParseFromRequest(r, func(token *jwt.Token) (interface{}, error) {
+		token, err := request.ParseFromRequest(r, request.OAuth2Extractor, func(token *jwt.Token) (interface{}, error) {
 			return []byte("secret"), nil
 		})
 		if err != nil || !token.Valid {

--- a/app/handlers/login.go
+++ b/app/handlers/login.go
@@ -39,11 +39,12 @@ func (h *loginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	token := jwt.New(jwt.SigningMethodHS256)
-	token.Claims["exp"] = time.Now().Add(time.Hour * 72).Unix()
-	token.Claims["iss"] = "auth.service"
-	token.Claims["iat"] = time.Now().Unix()
-	token.Claims["email"] = user.Email
-	token.Claims["sub"] = user.Username
+	claims := token.Claims.(jwt.MapClaims)
+	claims["exp"] = time.Now().Add(time.Hour * 72).Unix()
+	claims["iss"] = "auth.service"
+	claims["iat"] = time.Now().Unix()
+	claims["email"] = user.Email
+	claims["sub"] = user.Username
 
 	tokenString, err := token.SignedString([]byte(h.secret))
 	if err != nil {


### PR DESCRIPTION
The go-jwt package has [breaking api changes](https://github.com/dgrijalva/jwt-go/blob/master/MIGRATION_GUIDE.md#migration-guide-from-v2---v3) from v2 to v3, requiring some of the calling conventions to change.

This works using `go build` for me

An alternative would be to pin the jwt dependency to the particular v2 version string that was used to build this repo, if the maintainers prefer.

